### PR TITLE
Stream gene finder output directly

### DIFF
--- a/src/nontn7/main.sh
+++ b/src/nontn7/main.sh
@@ -7,14 +7,13 @@ set -euo pipefail  # Halt the pipeline if any errors are encountered
 OUTPUT=../../output/nontn7
 DATA=../../data
 STORE=$HOME/work
-INPUT="$STORE/missing-effectors $STORE/missing-effectors2 $STORE/pipeline-results"
+INPUT=$(ls /stor/work/Wilke/amh7958/pipeline-results/*tar.gz /stor/work/Wilke/amh7958/pipeline-results/missing_effectors/*.tar.gz)
 BLASTN_DB="$STORE/trnadb/trnas.fa"
 BLASTP_DB="$STORE/uniprotdb/uniprot_combined.fasta"
 REBLAST_OUTPUT_DIR="$OUTPUT/reblast"
 MIN_REBLAST_CLUSTER_SIZE=1
 REBLAST_COUNT=3
-KEEP_PATHS="NO"  # change to "YES" if you're running this pipeline on some other system than the Wilke cluster. You may need to update the paths to the FASTA files in the gene_finder CSVs manually
-
+KEEP_PATHS="NO"  # change to "YES" if you're running this pipeline on some other system than the Wilke cluster. You will need to update the values for $STORE and $INPUT, and probably most of the hard-coded values listed above.
 
 # TODO: This looks ridiculous because we removed the weird corner cases it allowed us to use.
 # It can be replaced by a simple list of strings probably.
@@ -52,11 +51,13 @@ mkdir -p $REBLAST_OUTPUT_DIR
 
 minimal_file=$OUTPUT/minimal_passing_operons.csv.gz
 if [[ ! -e $minimal_file ]]; then
-    fd '.*csv' $INPUT | parallel -j2 'cat {}' | python fix_paths.py $KEEP_PATHS | python rules-all.py | python rules-nocas1-2.py | gzip > $minimal_file
+    for filename in $INPUT; do
+        # stream tar files to stdout
+        tar -xzOf $filename
+    done | python fix_paths.py $KEEP_PATHS | python rules-all.py | python rules-nocas1-2.py | gzip > $minimal_file
 else
     >&2 echo "Minimal file already exists. Skipping..."
 fi 
-
 
 
 # ======================================================================================================


### PR DESCRIPTION
Previously I was decompressing the gene finder output and saving it to disk, but this was unnecessary and wasn't part of the pipeline. Now the operons are decompressed and streamed directly from the original files.