### PR TITLE
remove analysis directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,5 @@ James R. Rybarski, Kuang Hu, Alexis Hill, Claus O. Wilke, Ilya J. Finkelstein
 This repository contains analysis scripts and processed data for the project. It is structured as follows:
 
 - `data/`: raw data (excludes large datafiles assembled during metagenomic analysis)
-- `analysis/`: final analysis scripts and plots
-- `src/`: scripts for data pre-processing
-- `output/`: Intermediate outputs such as pre-processed data that are ready for analysis
+- `src/`: scripts for data processing
+- `output/`: outputs such as pre-processed data that are ready for analysis, as well as final analyses used in figures

--- a/analysis/README.md
+++ b/analysis/README.md
@@ -1,3 +1,0 @@
-This folder contains the following: 
-
-- ...


### PR DESCRIPTION
Yesterday, Kuang and I discussed removing the `analysis` directory, since it was unused. Almost all of our figures are effectively qualitative descriptions of the contents of the `output` directory, so splitting the code in two directories feels a bit awkward as the `src` directory would still contain >95% of the code.