### PR TITLE
Final sequence structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,5 +5,6 @@ James R. Rybarski, Kuang Hu, Alexis Hill, Claus O. Wilke, Ilya J. Finkelstein
 This repository contains analysis scripts and processed data for the project. It is structured as follows:
 
 - `data/`: raw data (excludes large datafiles assembled during metagenomic analysis)
+- `final_sequences/`: FASTA files and CSVs for each of the CASTs described in the manuscript
 - `src/`: scripts for data processing
 - `output/`: outputs such as pre-processed data that are ready for analysis, as well as final analyses used in figures

--- a/final_sequences/README.md
+++ b/final_sequences/README.md
@@ -1,0 +1,6 @@
+# Final Sequences
+
+This directory contains the following:
+
+  - `fasta/`: FASTA-formatted files, one per CAST
+  - `gene_finder_csv/`: the `gene_finder`-formatted CSV files

--- a/final_sequences/fasta/README.md
+++ b/final_sequences/fasta/README.md
@@ -1,0 +1,6 @@
+# Final FASTA files
+
+This directory contains the following:
+  - `tn7` Class 1 Tn7 CASTs  
+  - `tny-type-v` Type V Tn7 CASTs  
+  - `nontn7` Putative Rpn-Cas12a/Cascade CASTs  

--- a/final_sequences/fasta/README.md
+++ b/final_sequences/fasta/README.md
@@ -2,5 +2,5 @@
 
 This directory contains the following:
   - `tn7` Class 1 Tn7 CASTs  
-  - `tny-type-v` Type V Tn7 CASTs  
+  - `tn7-type-v` Type V Tn7 CASTs  
   - `nontn7` Putative Rpn-Cas12a/Cascade CASTs  


### PR DESCRIPTION
I've added the readme files describing the overall structure for the "final" sequences. Since git won't add empty directories, some of them are just implied by the readme text. For the gene_finder-formatted CSV data, I'm proposing to just have those be one CSV per subsystem since that's how they're already organized.