### PR TITLE
Add directory for genbank files

### DIFF
--- a/final_sequences/README.md
+++ b/final_sequences/README.md
@@ -3,4 +3,5 @@
 This directory contains the following:
 
   - `fasta/`: FASTA-formatted files, one per CAST
+  - `genbank/`: Genbank-formatted files, one per CAST
   - `gene_finder_csv/`: the `gene_finder`-formatted CSV files

--- a/final_sequences/genbank/README.md
+++ b/final_sequences/genbank/README.md
@@ -1,0 +1,6 @@
+# Final Genbank files
+
+This directory contains the following:
+  - `tn7` Class 1 Tn7 CASTs  
+  - `tn7-type-v` Type V Tn7 CASTs  
+  - `nontn7` Putative Rpn-Cas12a/Cascade CASTs  


### PR DESCRIPTION
We decided to add genbank files for each system since they can address many use cases that the protein FASTAs and gene_finder output cannot.