### PR TITLE
rename Cas12a to Cas12 for Rpn-associated Cas12

### DIFF
--- a/final_sequences/fasta/README.md
+++ b/final_sequences/fasta/README.md
@@ -3,4 +3,4 @@
 This directory contains the following:
   - `tn7` Class 1 Tn7 CASTs  
   - `tn7-type-v` Type V Tn7 CASTs  
-  - `nontn7` Putative Rpn-Cas12a/Cascade CASTs  
+  - `nontn7` Putative Rpn-Cas12/Cascade CASTs  

--- a/final_sequences/genbank/README.md
+++ b/final_sequences/genbank/README.md
@@ -3,4 +3,4 @@
 This directory contains the following:
   - `tn7` Class 1 Tn7 CASTs  
   - `tn7-type-v` Type V Tn7 CASTs  
-  - `nontn7` Putative Rpn-Cas12a/Cascade CASTs  
+  - `nontn7` Putative Rpn-Cas12/Cascade CASTs  

--- a/final_sequences/gene_finder_csv/README.md
+++ b/final_sequences/gene_finder_csv/README.md
@@ -3,4 +3,4 @@
 This directory contains the following:
   - `tn7` Class 1 Tn7 CASTs  
   - `tn7-type-v` Type V Tn7 CASTs  
-  - `nontn7` Putative Rpn-Cas12a/Cascade CASTs  
+  - `nontn7` Putative Rpn-Cas12/Cascade CASTs  

--- a/src/nontn7/find-cas12-sts.py
+++ b/src/nontn7/find-cas12-sts.py
@@ -1,4 +1,4 @@
-# do a pairwise search between the source (defined above) and 25kb upstream of cas12a and 25kb downstream of the array
+# do a pairwise search between the source (defined above) and 25kb upstream of cas12 and 25kb downstream of the array
 # create Features of top hits and source
 
 


### PR DESCRIPTION
Since the Rpn-associated Cas12 proteins may belong to a new subtype, we're renaming all references to them from Cas12a to Cas12, both here and in the manuscript.